### PR TITLE
Add syntax highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You need to add `RefreshableNavigationView(title: String, action: () -> Void, co
 
 Example: 
 
-``` language: swift
+```swift
 struct ContentView: View {
     @State var numbers:[Int] = [23,45,76,54,76,3465,24,423]
     
@@ -42,8 +42,6 @@ struct ContentView: View {
         }
         return sequence
     }
-    
-    
 }
 ```
 


### PR DESCRIPTION
Currently example code in README.md is not highlighted due to language not being passed correctly to the code block.